### PR TITLE
Fixes #33 - Adds local settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@ __pycache__/
 instance/
 .webassets-cache
 
+# Heroku environmental variables
+.env
+
 # virtualenv
 .venv
 venv/
+env/
+
+# IDEs
+.vscode


### PR DESCRIPTION
I didn't realize @karlcow had set this up differently than webcompat.com, so I've been using `virtualenv` here, which uses `env`, rather than `venv`. I also added `.vscode`, which is where workspace settings (like linters and whatnot) for specific projects in Code get stored.

Because [heroku makes it easy to run locally by automatically grabbing variables from `.env`](https://devcenter.heroku.com/articles/heroku-local#set-up-your-local-environment-variables), I added that as well. This way it's possible for someone to assign `DATABASE_URL` a path to a local postgresql db with test data so as not to muck around with the real thing*.

*(... which I will be able to upload someday if `github-backup` ever gets to run all the way through without freaking out or keeling over 🙄 ).