### PR TITLE
Fixes #35 - Adds python packages for postgresql to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ APScheduler==3.5.1
 python-dotenv==0.8.2
 flake8==3.5.0
 nose2==0.7.4
+psycopg2-binary==2.7.5
+Flask-SQLAlchemy==2.3.2


### PR DESCRIPTION
It took me a while to figure out I had to update `requirements.txt` by hand in order not to add unnecessary packages (`pipenv` has made me lazy). Or at least, that's what seemed the most expedient way to a noob.