### PR TITLE
Fixes #58 - Unbreak tests on master caused by missing local secret key

### DIFF
--- a/ochazuke/__init__.py
+++ b/ochazuke/__init__.py
@@ -43,17 +43,18 @@ def create_app(test_config=None):
 
     app.register_blueprint(webhooks)
 
-    app.config['HOOK_SECRET_KEY'] = os.environ.get('HOOK_SECRET_KEY')
-
-    # configure the postgresql database
+    # configure the postgresql database & the github webhook secret key
     if test_config is None:
-        # fetch the environmental variable for the database location
+        # fetch the environment variables for the database and hook secret
         database_url = os.environ.get('DATABASE_URL')
+        hook_secret = os.environ.get('HOOK_SECRET_KEY')
     else:
-        # use the local database for testing
+        # use the local database for testing and a dummy secret
         database_url = 'postgresql://localhost/metrics'
+        hook_secret = 'SECRETS'
     app.config['SQLALCHEMY_DATABASE_URI'] = database_url
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['HOOK_SECRET_KEY'] = hook_secret
     db.init_app(app)
 
     # A route for starting

--- a/ochazuke/webhook/helpers.py
+++ b/ochazuke/webhook/helpers.py
@@ -25,9 +25,8 @@ UPDATE = 'Update'
 
 def get_payload_signature(key, payload):
     """Compute the payload signature given a key."""
-    key = key.encode('utf-8')
     # HMAC requires its key to be encoded bytes
-    mac = hmac.new(key, msg=payload, digestmod=hashlib.sha1)
+    mac = hmac.new(b'key', msg=payload, digestmod=hashlib.sha1)
     return mac.hexdigest()
 
 


### PR DESCRIPTION
Does the existing `FLASK_CONFIG` environment variable set in Circle mean setting the hook secret in there is now unnecessary? (Or maybe I should worry about that later when I get the CI database configuration figured out and changed.)