### PR TITLE
Fixes #70 - Adds .env to .gitignore

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-FLASK_APP=ochazuke

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ instance/
 
 # virtualenv
 .venv
-venv/
+venv/.env


### PR DESCRIPTION
This removes the .env file on the project.
It can still exist for people locally.
And it adds it to .gitignore so we do not commit it again by mistake in the future.