### PR TITLE
Fixes #92 - Create a temp test route querying DB

### DIFF
--- a/ochazuke/__init__.py
+++ b/ochazuke/__init__.py
@@ -8,6 +8,7 @@
 
 import os
 import logging
+import json
 
 from flask import Flask
 from flask import request
@@ -106,17 +107,17 @@ def create_app(test_config=None):
         if is_valid_args(request.args):
             date_pair = normalize_date_range(
                 request.args.get('from'), request.args.get('to'))
-            with app.app_context():
-                needsdiagnosis_data = IssuesCount.query.filter_by(
-                    milestone='needsdiagnosis').filter(
-                        IssuesCount.timestamp.between(
-                            date_pair[0], date_pair[1])).all()
+            needsdiagnosis_data = IssuesCount.query.filter_by(
+                milestone='needsdiagnosis').filter(
+                    IssuesCount.timestamp.between(
+                        date_pair[0], date_pair[1])).all()
             timeline = []
             for item in needsdiagnosis_data:
                 hourly_count = dict(
                     timestamp=item.timestamp.isoformat()+'Z',
                     count=item.count)
                 timeline.append(hourly_count)
+            timeline = json.dumps(timeline)
             response = Response(
                 response=timeline,
                 status=200,

--- a/ochazuke/__init__.py
+++ b/ochazuke/__init__.py
@@ -138,6 +138,6 @@ def create_app(test_config=None):
 # it will create a line with the following format
 # (2015-09-14 20:50:19) INFO: Thing_To_Log
 logging.basicConfig(format='(%(asctime)s) %(levelname)s: %(message)s',
-                    datefmt='%Y-%m-%d  % H:%M:%S %z', level=logging.INFO)
+                    datefmt='%Y-%m-%d  %H:%M:%S %z', level=logging.INFO)
 
 app = create_app()

--- a/ochazuke/__init__.py
+++ b/ochazuke/__init__.py
@@ -106,10 +106,11 @@ def create_app(test_config=None):
         if is_valid_args(request.args):
             date_pair = normalize_date_range(
                 request.args.get('from'), request.args.get('to'))
-            needsdiagnosis_data = IssuesCount.query.filter_by(
-                milestone='needsdiagnosis').filter(
-                    IssuesCount.timestamp.between(
-                        date_pair[0], date_pair[1])).all()
+            with app.app_context():
+                needsdiagnosis_data = IssuesCount.query.filter_by(
+                    milestone='needsdiagnosis').filter(
+                        IssuesCount.timestamp.between(
+                            date_pair[0], date_pair[1])).all()
             timeline = []
             for item in needsdiagnosis_data:
                 hourly_count = dict(

--- a/ochazuke/__init__.py
+++ b/ochazuke/__init__.py
@@ -15,6 +15,7 @@ from flask import Response
 
 from ochazuke.helpers import get_json_slice
 from ochazuke.helpers import is_valid_args
+from ochazuke.helpers import normalize_date_range
 from tools.helpers import get_remote_data
 from ochazuke.models import db
 from ochazuke.models import IssuesCount
@@ -103,11 +104,12 @@ def create_app(test_config=None):
     def needsdiagnosis_from_db():
         """Test route that queries database to serve data to client."""
         if is_valid_args(request.args):
+            date_pair = normalize_date_range(
+                request.args.get('from'), request.args.get('to'))
             needsdiagnosis_data = IssuesCount.query.filter_by(
-                milestone="needsdiagnosis").filter(
+                milestone='needsdiagnosis').filter(
                     IssuesCount.timestamp.between(
-                        request.args.get('from'), request.args.get('to'))
-            ).all()
+                        date_pair[0], date_pair[1])).all()
             timeline = []
             for item in needsdiagnosis_data:
                 hourly_count = dict(

--- a/ochazuke/helpers.py
+++ b/ochazuke/helpers.py
@@ -73,3 +73,24 @@ def is_valid_args(args):
         else:
             return True
     return False
+
+
+def normalize_date_range(from_date, to_date):
+    """Add a day to the to_date so dates are inclusive in a database query.
+
+    A date is a string 'YYYY-MM-DD'
+    A date is considered to be starting at 00:00:00.
+    An invalid date format should be ignored and return None.
+    The same from_date and to_date should return from_date.
+    """
+    date_format = '%Y-%m-%d'
+    try:
+        start = datetime.datetime.strptime(from_date, date_format)
+        end = datetime.datetime.strptime(to_date, date_format)
+    except Exception:
+        return None
+    else:
+        new_end_date = end + datetime.timedelta(days=1)
+        dates = [start.strftime(date_format), new_end_date.strftime(
+            date_format)]
+    return dates


### PR DESCRIPTION
I learned a couple of things about timestamp defaults by messing around on a python heroku console (my new bff) that may prove important to remember going forward:

1. Since DailyTotals days are saved a python datetimes, they automatically get a midnight timestamp

2. Time is taken into account when filtering SQL with the "BETWEEN" command. Between is inclusive, but if you don't specify a time... SQL assumes midnight (00:00:00). This means that if you search between, say, Feb. 25 and Feb. 26, without specifying a time -- you get back nothing from Feb. 26 that happened after the stroke of 24:00... so basically, only results from Feb. 25. 

In writing this, I just realized that I forgot to go back and address point num. 2 in this PR. 🤦‍♀️  New commit coming soon. 😜 