### PR TITLE
Fixes #106 - Add weekly total model and script to populate it

### DIFF
--- a/bin/weekly_total.py
+++ b/bin/weekly_total.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Compute and store the total issues reported each week on webcompat.
+"""
+
+import sys
+import logging
+import datetime
+import sqlalchemy
+
+from ochazuke import create_app
+from ochazuke.models import db
+from ochazuke.models import DailyTotal
+from ochazuke.models import WeeklyTotal
+
+# Config
+LOGGER = logging.getLogger(__name__)
+
+
+def main():
+    """Code to query DB for a week of counts, sum them, and store result."""
+    # NOTE: This works as expected if script is scheduled in UTC
+    today = datetime.date.today()
+    monday = today - datetime.timedelta(days=7)
+    sunday = today - datetime.timedelta(days=1)
+    # Put last Monday and yesterday's dates into format: 2019-01-30
+    monday = monday.isoformat()
+    sunday = sunday.isoformat()
+
+    # Create an app context and store the data in the database
+    app = create_app('production')
+    with app.app_context():
+        date_range = DailyTotal.day.between(monday, sunday)
+        LOGGER.info('MONDAY: {}'.format(monday))
+        LOGGER.info('SUNDAY: {}'.format(sunday))
+        LOGGER.info('DATE_RANGE {}'.format(date_range))
+        week_list = DailyTotal.query.filter(date_range).all()
+        LOGGER.info('COUNTS FOR WEEK {}'.format(week_list))
+        week_total = 0
+        if not week_list:
+            # On a query failure, log an error
+            msg = "Weekly count query failed for {}!".format(monday)
+            LOGGER.warning(msg)
+            return
+        for day in week_list:
+            week_total += day.count
+        weekly_count = WeeklyTotal(monday=monday, count=week_total)
+        db.session.add(weekly_count)
+        try:
+            db.session.commit()
+            msg = (
+                "Successfully wrote count for {} in WeeklyTotal table."
+                ).format(monday)
+            LOGGER.info(msg)
+        # Catch error and attempt to recover by resetting staged changes.
+        except sqlalchemy.exc.SQLAlchemyError as error:
+            db.session.rollback()
+            msg = ("Yikes! Failed to write data for {week} in "
+                   "WeeklyTotal table: {err}").format(week=monday, err=error)
+            LOGGER.warning(msg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ochazuke/models.py
+++ b/ochazuke/models.py
@@ -28,8 +28,28 @@ class DailyTotal(db.Model):
             day=self.day, count=self.count)
 
 
+class WeeklyTotal(db.Model):
+    """Define a WeeklyTotal for new issues filed.
+
+    An weekly total has:
+
+    * a unique table id
+    * a monday representing the date of the (iso) week's starting Monday
+    * a count of the issues filed during the week (Monday-Sunday)
+    """
+    __tablename__ = 'weekly_total'
+    id = db.Column(db.Integer, primary_key=True)
+    monday = db.Column(db.DateTime, nullable=False)
+    count = db.Column(db.Integer, nullable=False)
+
+    def __repr__(self):
+        """Return a representation of a WeeklyTotal."""
+        return "<WeeklyTotal for week of {monday}: {count}".format(
+            monday=self.monday, count=self.count)
+
+
 class IssuesCount(db.Model):
-    """Define a IssuesCount for milestone at a precise time.
+    """Define an IssuesCount for milestone at a precise time.
 
     An issues count has:
 


### PR DESCRIPTION
In this version, the `weekly_total` script will be set up to run in the early (UTC) hours of every Monday to calculate the previous week's total new issue reports.

To have a "so far this week" tally, we'd either need to:

- add code to the endpoint to query both the weekly_total and daily_total tables

OR

- incorporate a running count into the `daily_total` script (e.g., add each day's total to the current weekly timestamp in `weekly_total` as well as the individual day's timestamp in `daily_total`)

**Edited to add:*** The current default setup for the client side doesn't include the current unfinished week (although you can manually force it), so the "so far this week" point may be moot. (Also, if we don't make some note somewhere that the current week isn't closed yet, it may be misleading.)

**Note:** There will still be the step to add the back-data to the weekly_total table once the script is set up and functioning correctly.