### PR TITLE
Fixes #122 - Change weekly report endpoint to query DB

### DIFF
--- a/ochazuke/helpers.py
+++ b/ochazuke/helpers.py
@@ -10,6 +10,7 @@ import json
 
 from ochazuke import logging
 from ochazuke.models import IssuesCount
+from ochazuke.models import WeeklyTotal
 
 
 def get_days(from_date, to_date):
@@ -122,4 +123,21 @@ def get_timeline_data(category, start, end):
                  'count': issue.count,
                  'timestamp': issue.timestamp.isoformat()+'Z'
                 } for issue in issues_list]
+    return timeline
+
+
+def get_weekly_data(start, end):
+    """Query the data in the DB for weekly bug counts."""
+    # Extract the list of issues
+    date_range = WeeklyTotal.monday.between(start, end)
+    msg = ('DATE_RANGE {dr}, where timestamp_1 = {t1}'
+           ' and timestamp_2 = {t2}').format(dr=date_range, t1=start, t2=end)
+    logging.info(msg)
+    reports_list = WeeklyTotal.query.filter(date_range).order_by(
+        WeeklyTotal.monday.asc()).all()
+    logging.info('REPORTS {}'.format(reports_list))
+    timeline = [{
+                 'count': report.count,
+                 'timestamp': report.monday.isoformat()+'Z'
+                } for report in reports_list]
     return timeline

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -29,11 +29,10 @@ DATA2 = [{"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
          {"count": "485", "timestamp": "2018-05-18T04:00:00Z"},
          ]
 
-WEEKLY_DATA = {
-    "2015": [9, 7, 46],
-    "2016": [11, 19, 28],
-    "2017": [35, 29, 40]
-}
+WEEKLY_DATA = [{"count": 471, "timestamp": "2019-05-20T00:00:00Z"},
+               {"count": 392, "timestamp": "2019-05-27T00:00:00Z"},
+               {"count": 407, "timestamp": "2019-06-03T00:00:00Z"}
+               ]
 
 
 def mocked_json(expected_data):
@@ -68,12 +67,16 @@ class APITestCase(unittest.TestCase):
         db.drop_all()
         self.app_context.pop()
 
-    @patch('ochazuke.api.views.get_remote_data')
+    @patch('ochazuke.api.views.get_weekly_data')
     def test_weeklydata(self, mock_get):
         """Send back on /data/weekly-counts a JSON."""
-        mock_get.return_value = mocked_json(WEEKLY_DATA)
-        rv = self.client.get('/data/weekly-counts')
-        self.assertIn('"2016": [11, 19, 28]', rv.data.decode())
+        mock_get.return_value = WEEKLY_DATA
+        rv = self.client.get(
+            '/data/weekly-counts?from=2019-05-16&to=2019-06-04')
+        self.assertIn(
+            (
+                '{"count": 392, "timestamp": "2019-05-27T00:00:00Z"}'
+            ), rv.data.decode())
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.mimetype, 'application/json')
         self.assertTrue('Access-Control-Allow-Origin' in rv.headers.keys())


### PR DESCRIPTION
HOLD until PR #121 is approved and script has been run. (We should wait until we have all the back data migrated so queries don't unexpectedly fail.)

@karlcow If you see any way to make anything more DRY, let me know. There's a lot of similarity between the milestone count endpoint, but not quite enough (that I could see) to make it easy to factor out functions.

