### PR TITLE
Fixes #100 - Merge code of conduct with Mozilla-required boilerplate

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,15 @@
-# Contributor Covenant Code of Conduct
+## Mozilla Community Participation Guidelines
 
-## Our Pledge
+This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
+
+## How to Report
+For more information on how to report violations of the Community Participation Guidelines, please read our [How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.
+
+## Project Specific Etiquette
+
+### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to make participation in our project and
@@ -9,7 +18,7 @@ size, disability, ethnicity, gender identity and expression, level of experience
 nationality, personal appearance, race, religion, or sexual identity and
 orientation.
 
-## Our Standards
+### Our Standards
 
 Examples of behavior that contribute to creating a positive environment
 include:
@@ -31,7 +40,7 @@ Examples of unacceptable behavior by participants include:
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
@@ -43,7 +52,7 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behavior that they deem inappropriate,
 threatening, offensive, or harmful.
 
-## Scope
+### Scope
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
@@ -52,7 +61,7 @@ address, posting via an official social media account, or acting as an appointed
 representative at an online or offline event. Representation of a project may be
 further defined and clarified by project maintainers.
 
-## Enforcement
+### Enforcement
 
 Instances of abuse, harassment, or otherwise unacceptable behavior may be
 reported by contacting the project team at [Mike](mailto:miket@mozilla.com) / [@miketaylr](https://github.com/miketaylr) or [Karl](mailto:kdubost@mozilla.com) / [@karlcow](https://github.com/karlcow) or [Guillaume](mailto:magsout@gmail.com) / [@magsout](https://github.com/magsout). All
@@ -65,9 +74,9 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
-## Attribution
+### Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+This project specific code of conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
 available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org


### PR DESCRIPTION
This may not be necessary, strictly speaking, but it seemed like an easy enough fix.