### PR TITLE
Fixes #128 - Clean out dead code from tests

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -13,31 +13,15 @@ from ochazuke import create_app
 from ochazuke import db
 
 
-TIMELINE = {'about': 'Hourly NeedsDiagnosis issues count',
-            'date_format': 'w3c',
-            'timeline': []
-            }
-
-DATA = [{"count": "485", "timestamp": "2018-05-15T01:00:00Z"},
-        {"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
+DATA = [{"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
         {"count": "485", "timestamp": "2018-05-17T03:00:00Z"},
         {"count": "485", "timestamp": "2018-05-18T04:00:00Z"},
         ]
-
-DATA2 = [{"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
-         {"count": "485", "timestamp": "2018-05-17T03:00:00Z"},
-         {"count": "485", "timestamp": "2018-05-18T04:00:00Z"},
-         ]
 
 WEEKLY_DATA = [{"count": 471, "timestamp": "2019-05-20T00:00:00Z"},
                {"count": 392, "timestamp": "2019-05-27T00:00:00Z"},
                {"count": 407, "timestamp": "2019-06-03T00:00:00Z"}
                ]
-
-
-def mocked_json(expected_data):
-    """Prepare a json response when fed a dictionary."""
-    return json.dumps(expected_data)
 
 
 def json_data(filename):
@@ -91,7 +75,7 @@ class APITestCase(unittest.TestCase):
     @patch('ochazuke.api.views.get_timeline_data')
     def test_needsdiagnosis_valid_param(self, mock_timeline):
         """Valid parameters on /needsdiagnosis-timeline."""
-        mock_timeline.return_value = DATA2
+        mock_timeline.return_value = DATA
         url = '/data/needsdiagnosis-timeline?from=2018-05-16&to=2018-05-18'
         rv = self.client.get(url)
         self.assertIn(

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Main testing module for Webcompat Metrics Server."""
-import json
-import os
 import unittest
 
 from werkzeug.datastructures import ImmutableMultiDict
@@ -14,42 +12,11 @@ from ochazuke import create_app
 from ochazuke import helpers
 
 
-TIMELINE = {'about': 'Hourly NeedsDiagnosis issues count',
-            'date_format': 'w3c',
-            'timeline': []
-            }
-
 DATA = [{"count": "485", "timestamp": "2018-05-15T01:00:00Z"},
         {"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
         {"count": "485", "timestamp": "2018-05-17T03:00:00Z"},
         {"count": "485", "timestamp": "2018-05-18T04:00:00Z"},
         ]
-
-DATA2 = [{"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
-         {"count": "485", "timestamp": "2018-05-17T03:00:00Z"},
-         {"count": "485", "timestamp": "2018-05-18T04:00:00Z"},
-         ]
-
-WEEKLY_DATA = {
-    "2015": [9, 7, 46],
-    "2016": [11, 19, 28],
-    "2017": [35, 29, 40]
-}
-
-
-def mocked_json(expected_data):
-    """Prepare a json response when fed a dictionary."""
-    return json.dumps(expected_data)
-
-
-def json_data(filename):
-    """Return a tuple with the content and its signature."""
-    current_root = os.path.realpath(os.curdir)
-    fixtures_path = 'tests/fixtures'
-    path = os.path.join(current_root, fixtures_path, filename)
-    with open(path, 'r') as f:
-        json_event = json.dumps(json.load(f))
-    return json_event
 
 
 class HelpersTestCase(unittest.TestCase):


### PR DESCRIPTION
Tests still run fine, so I think some of this was just copied between files during the refactoring and left in by accident. I went ahead and changed the `DATA2` constant in `test_api` to just `DATA`. Let me know if I got overzealous anywhere @karlcow 😁 