### PR TITLE
Fixes #69 - Create migration scripts for DB [WIP]

### DIFF
--- a/ochazuke/__init__.py
+++ b/ochazuke/__init__.py
@@ -10,21 +10,25 @@ import logging
 
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
 
 from config import config
 
 
 db = SQLAlchemy()
+migrate = Migrate()
 
 
 def create_app(config_name):
     """Create the main webcompat metrics server app."""
-    # create and configure the app
+    # Create and configure the app
     app = Flask(__name__)
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
     # DB init
     db.init_app(app)
+    # Migration setup
+    migrate.init_app(app, db)
     # Blueprint
     configure_blueprints(app)
     return app
@@ -34,10 +38,12 @@ def configure_blueprints(app):
     """Define the blueprints for the project."""
     # Web views for humans
     from ochazuke.web import web_blueprint
+
     app.register_blueprint(web_blueprint)
     # Views for API clients
     from ochazuke.api import api_blueprint
-    app.register_blueprint(api_blueprint, url_prefix='/data')
+
+    app.register_blueprint(api_blueprint, url_prefix="/data")
 
 
 # Logging Capabilities
@@ -45,5 +51,13 @@ def configure_blueprints(app):
 #   app.logger.info(Thing_To_Log)
 # it will create a line with the following format
 # (2015-09-14 20:50:19) INFO: Thing_To_Log
-logging.basicConfig(format='(%(asctime)s) %(levelname)s: %(message)s',
-                    datefmt='%Y-%m-%d  %H:%M:%S %z', level=logging.INFO)
+logging.basicConfig(
+    format="(%(asctime)s) %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d  %H:%M:%S %z",
+    level=logging.INFO,
+)
+
+application = create_app("development")
+
+if __name__ == "__main__":
+    application.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flake8==3.7.7
 nose2==0.9.1
 psycopg2-binary==2.8.2
 Flask-SQLAlchemy==2.4.0
+Flask-Migrate==2.5.2


### PR DESCRIPTION
This works locally to generate scripts, but I need to change the "development" config before we merge and I run everything again locally and then on Heroku to add the `migrations` dir, so we either need this to:
 
1) automatically detect the correct current config from `FLASK_ENV` (or whatever we want to call this)

**or**

2) hardcode it as "production" config (as we did with the Scheduler scripts ... which in retrospect seems silly -- exporting a config variable there would have made the data loading I did at AllHands much easier 🤦‍♀ )

Which brings me to a question about the current `config.py` file and how it's being used, because it seems inconsistent to me. This could be me missing something, but it looks like:

we're using exporting `FLASK_ENV` for dev setup:
https://github.com/webcompat/webcompat-metrics-server/blob/63648050e3416eb58b3d886ffeb119fcbc786c7c/config.py#L24

hardcoding a `production` config for Heroku:
https://github.com/webcompat/webcompat-metrics-server/blob/63648050e3416eb58b3d886ffeb119fcbc786c7c/Procfile#L1

hardcoding a `production` config for the Scheduler scripts:
https://github.com/webcompat/webcompat-metrics-server/blob/63648050e3416eb58b3d886ffeb119fcbc786c7c/bin/daily_total.py#L71

setting a `FLASK_CONFIG` to `testing` on CircleCI:
https://github.com/webcompat/webcompat-metrics-server/blob/63648050e3416eb58b3d886ffeb119fcbc786c7c/.circleci/config.yml#L13

Should we consider using `FLASK_ENV` or `FLASK_CONFIG` consistently across all these instances, @karlcow? Or is there a reason this is safer/better/necessary?