### PR TITLE
Fixes #131 - Add route to serve TSCI info

### DIFF
--- a/ochazuke/api/views.py
+++ b/ochazuke/api/views.py
@@ -43,7 +43,9 @@ def weekly_reports_data():
         "timeline": timeline,
     }
     response = Response(
-        response=json.dumps(response_object), status=200, mimetype="application/json",
+        response=json.dumps(response_object),
+        status=200,
+        mimetype="application/json",
     )
     response.headers.add("Access-Control-Allow-Origin", "*")
     response.headers.add("Access-Control-Allow-Credentials", "true")
@@ -74,7 +76,9 @@ def issues_count_data(category):
         "timeline": timeline,
     }
     response = Response(
-        response=json.dumps(response_object), status=200, mimetype="application/json",
+        response=json.dumps(response_object),
+        status=200,
+        mimetype="application/json",
     )
     response.headers.add("Access-Control-Allow-Origin", "*")
     response.headers.add("Access-Control-Allow-Credentials", "true")
@@ -87,7 +91,9 @@ def triage_bugs():
     """Returns the list of issues which are currently in triage."""
     url = "https://api.github.com/repos/webcompat/web-bugs/issues?sort=created&per_page=100&direction=asc&milestone=2"  # noqa
     json_data = get_remote_data(url)
-    response = Response(response=json_data, status=200, mimetype="application/json")
+    response = Response(
+        response=json_data, status=200, mimetype="application/json"
+    )
     response.headers.add("Access-Control-Allow-Origin", "*")
     response.headers.add("Access-Control-Allow-Credentials", "true")
     response.headers.add("Vary", "Origin")
@@ -99,7 +105,9 @@ def tsci_doc():
     """Returns the current ID of the spreadsheet where TSCI is calculated."""
     url = "https://tsci.webcompat.com/currentDoc.json"  # noqa
     json_data = get_remote_data(url)
-    response = Response(response=json_data, status=200, mimetype="application/json")
+    response = Response(
+        response=json_data, status=200, mimetype="application/json"
+    )
     response.headers.add("Access-Control-Allow-Origin", "*")
     response.headers.add("Access-Control-Allow-Credentials", "true")
     response.headers.add("Vary", "Origin")

--- a/ochazuke/api/views.py
+++ b/ochazuke/api/views.py
@@ -8,6 +8,7 @@
 import json
 
 from flask import abort
+
 # from flask import current_app as app
 from flask import request
 from flask import Response
@@ -21,7 +22,7 @@ from ochazuke.helpers import normalize_date_range
 from tools.helpers import get_remote_data
 
 
-@api_blueprint.route('/weekly-counts')
+@api_blueprint.route("/weekly-counts")
 def weekly_reports_data():
     """Route for weekly bug reports."""
     if not request.args:
@@ -29,29 +30,28 @@ def weekly_reports_data():
     if not is_valid_args(request.args):
         abort(404)
     # Extract the dates
-    from_date = request.args.get('from')
-    to_date = request.args.get('to')
+    from_date = request.args.get("from")
+    to_date = request.args.get("to")
     # Adding the extra day for weekly reports isn't necessary, but won't hurt
     start, end = normalize_date_range(from_date, to_date)
     # Fetch the data
     timeline = get_weekly_data(from_date, to_date)
     # Prepare the response
     response_object = {
-        'about': 'Weekly Count of New Issues Reported',
-        'numbering_of_weeks': 'ISO calendar',
-        'timeline': timeline
+        "about": "Weekly Count of New Issues Reported",
+        "numbering_of_weeks": "ISO calendar",
+        "timeline": timeline,
     }
     response = Response(
-        response=json.dumps(response_object),
-        status=200,
-        mimetype='application/json')
-    response.headers.add('Access-Control-Allow-Origin', '*')
-    response.headers.add('Access-Control-Allow-Credentials', 'true')
-    response.headers.add('Vary', 'Origin')
+        response=json.dumps(response_object), status=200, mimetype="application/json",
+    )
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    response.headers.add("Access-Control-Allow-Credentials", "true")
+    response.headers.add("Vary", "Origin")
     return response
 
 
-@api_blueprint.route('/<category>-timeline')
+@api_blueprint.route("/<category>-timeline")
 def issues_count_data(category):
     """Route for issues count."""
     if not is_valid_category(category):
@@ -61,38 +61,46 @@ def issues_count_data(category):
     if not is_valid_args(request.args):
         abort(404)
     # Extract the dates
-    from_date = request.args.get('from')
-    to_date = request.args.get('to')
+    from_date = request.args.get("from")
+    to_date = request.args.get("to")
     start, end = normalize_date_range(from_date, to_date)
     # Grab the data
     timeline = get_timeline_data(category, start, end)
     # Prepare the response
-    about = 'Hourly {category} issues count'.format(category=category)
+    about = "Hourly {category} issues count".format(category=category)
     response_object = {
-        'about': about,
-        'date_format': 'w3c',
-        'timeline': timeline
+        "about": about,
+        "date_format": "w3c",
+        "timeline": timeline,
     }
     response = Response(
-        response=json.dumps(response_object),
-        status=200,
-        mimetype='application/json')
-    response.headers.add('Access-Control-Allow-Origin', '*')
-    response.headers.add('Access-Control-Allow-Credentials', 'true')
-    response.headers.add('Vary', 'Origin')
+        response=json.dumps(response_object), status=200, mimetype="application/json",
+    )
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    response.headers.add("Access-Control-Allow-Credentials", "true")
+    response.headers.add("Vary", "Origin")
     return response
 
 
-@api_blueprint.route('/triage-bugs')
+@api_blueprint.route("/triage-bugs")
 def triage_bugs():
     """Returns the list of issues which are currently in triage."""
-    url = 'https://api.github.com/repos/webcompat/web-bugs/issues?sort=created&per_page=100&direction=asc&milestone=2'  # noqa
+    url = "https://api.github.com/repos/webcompat/web-bugs/issues?sort=created&per_page=100&direction=asc&milestone=2"  # noqa
     json_data = get_remote_data(url)
-    response = Response(
-        response=json_data,
-        status=200,
-        mimetype='application/json')
-    response.headers.add('Access-Control-Allow-Origin', '*')
-    response.headers.add('Access-Control-Allow-Credentials', 'true')
-    response.headers.add('Vary', 'Origin')
+    response = Response(response=json_data, status=200, mimetype="application/json")
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    response.headers.add("Access-Control-Allow-Credentials", "true")
+    response.headers.add("Vary", "Origin")
+    return response
+
+
+@api_blueprint.route("/tsci-doc")
+def tsci_doc():
+    """Returns the current ID of the spreadsheet where TSCI is calculated."""
+    url = "https://tsci.webcompat.com/currentDoc.json"  # noqa
+    json_data = get_remote_data(url)
+    response = Response(response=json_data, status=200, mimetype="application/json")
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    response.headers.add("Access-Control-Allow-Credentials", "true")
+    response.headers.add("Vary", "Origin")
     return response

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -13,23 +13,27 @@ from ochazuke import create_app
 from ochazuke import db
 
 
-DATA = [{"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
-        {"count": "485", "timestamp": "2018-05-17T03:00:00Z"},
-        {"count": "485", "timestamp": "2018-05-18T04:00:00Z"},
-        ]
+DATA = [
+    {"count": "485", "timestamp": "2018-05-16T02:00:00Z"},
+    {"count": "485", "timestamp": "2018-05-17T03:00:00Z"},
+    {"count": "485", "timestamp": "2018-05-18T04:00:00Z"},
+]
 
-WEEKLY_DATA = [{"count": 471, "timestamp": "2019-05-20T00:00:00Z"},
-               {"count": 392, "timestamp": "2019-05-27T00:00:00Z"},
-               {"count": 407, "timestamp": "2019-06-03T00:00:00Z"}
-               ]
+WEEKLY_DATA = [
+    {"count": 471, "timestamp": "2019-05-20T00:00:00Z"},
+    {"count": 392, "timestamp": "2019-05-27T00:00:00Z"},
+    {"count": 407, "timestamp": "2019-06-03T00:00:00Z"},
+]
+
+TSCI_ID = [{"currentDoc": "8sXj8GqhrdJhQdLk44"}]
 
 
 def json_data(filename):
     """Return a tuple with the content and its signature."""
     current_root = os.path.realpath(os.curdir)
-    fixtures_path = 'tests/fixtures'
+    fixtures_path = "tests/fixtures"
     path = os.path.join(current_root, fixtures_path, filename)
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         json_event = json.dumps(json.load(f))
     return json_event
 
@@ -39,7 +43,7 @@ class APITestCase(unittest.TestCase):
 
     def setUp(self):
         """Set up tests."""
-        self.app = create_app('testing')
+        self.app = create_app("testing")
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.create_all()
@@ -51,84 +55,111 @@ class APITestCase(unittest.TestCase):
         db.drop_all()
         self.app_context.pop()
 
-    @patch('ochazuke.api.views.get_weekly_data')
+    @patch("ochazuke.api.views.get_weekly_data")
     def test_weeklydata(self, mock_get):
         """Send back on /data/weekly-counts a JSON."""
         mock_get.return_value = WEEKLY_DATA
         rv = self.client.get(
-            '/data/weekly-counts?from=2019-05-16&to=2019-06-04')
+            "/data/weekly-counts?from=2019-05-16&to=2019-06-04"
+        )
         self.assertIn(
-            (
-                '{"count": 392, "timestamp": "2019-05-27T00:00:00Z"}'
-            ), rv.data.decode())
+            ('{"count": 392, "timestamp": "2019-05-27T00:00:00Z"}'),
+            rv.data.decode(),
+        )
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.mimetype, 'application/json')
-        self.assertTrue('Access-Control-Allow-Origin' in rv.headers.keys())
-        self.assertEqual('*', rv.headers['Access-Control-Allow-Origin'])
-        self.assertTrue('Vary' in rv.headers.keys())
-        self.assertEqual('Origin', rv.headers['Vary'])
+        self.assertEqual(rv.mimetype, "application/json")
+        self.assertTrue("Access-Control-Allow-Origin" in rv.headers.keys())
+        self.assertEqual("*", rv.headers["Access-Control-Allow-Origin"])
+        self.assertTrue("Vary" in rv.headers.keys())
+        self.assertEqual("Origin", rv.headers["Vary"])
         self.assertTrue(
-            'Access-Control-Allow-Credentials' in rv.headers.keys())
-        self.assertEqual('true',
-                         rv.headers['Access-Control-Allow-Credentials'])
+            "Access-Control-Allow-Credentials" in rv.headers.keys()
+        )
+        self.assertEqual(
+            "true", rv.headers["Access-Control-Allow-Credentials"]
+        )
 
-    @patch('ochazuke.api.views.get_timeline_data')
+    @patch("ochazuke.api.views.get_timeline_data")
     def test_needsdiagnosis_valid_param(self, mock_timeline):
         """Valid parameters on /needsdiagnosis-timeline."""
         mock_timeline.return_value = DATA
-        url = '/data/needsdiagnosis-timeline?from=2018-05-16&to=2018-05-18'
+        url = "/data/needsdiagnosis-timeline?from=2018-05-16&to=2018-05-18"
         rv = self.client.get(url)
         self.assertIn(
             '{"count": "485", "timestamp": "2018-05-17T03:00:00Z"}',
-            rv.data.decode())
+            rv.data.decode(),
+        )
         self.assertIn(
-            '"about": "Hourly needsdiagnosis issues count"',
-            rv.data.decode())
+            '"about": "Hourly needsdiagnosis issues count"', rv.data.decode()
+        )
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.mimetype, 'application/json')
-        self.assertTrue('Access-Control-Allow-Origin' in rv.headers.keys())
-        self.assertEqual('*', rv.headers['Access-Control-Allow-Origin'])
-        self.assertTrue('Vary' in rv.headers.keys())
-        self.assertEqual('Origin', rv.headers['Vary'])
+        self.assertEqual(rv.mimetype, "application/json")
+        self.assertTrue("Access-Control-Allow-Origin" in rv.headers.keys())
+        self.assertEqual("*", rv.headers["Access-Control-Allow-Origin"])
+        self.assertTrue("Vary" in rv.headers.keys())
+        self.assertEqual("Origin", rv.headers["Vary"])
         self.assertTrue(
-            'Access-Control-Allow-Credentials' in rv.headers.keys())
-        self.assertEqual('true',
-                         rv.headers['Access-Control-Allow-Credentials'])
+            "Access-Control-Allow-Credentials" in rv.headers.keys()
+        )
+        self.assertEqual(
+            "true", rv.headers["Access-Control-Allow-Credentials"]
+        )
 
-    @patch('ochazuke.api.views.get_remote_data')
+    @patch("ochazuke.api.views.get_remote_data")
     def test_triage_stats(self, mock_get):
         """/data/triage-bugs sends back JSON."""
-        mock_get.return_value = json_data('triage.json')
-        rv = self.client.get('/data/triage-bugs')
+        mock_get.return_value = json_data("triage.json")
+        rv = self.client.get("/data/triage-bugs")
         self.assertIn(
-            '"title": "example.org - dashboard test"',
-            rv.data.decode())
+            '"title": "example.org - dashboard test"', rv.data.decode()
+        ),
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.mimetype, 'application/json')
-        self.assertTrue('Access-Control-Allow-Origin' in rv.headers.keys())
-        self.assertEqual('*', rv.headers['Access-Control-Allow-Origin'])
-        self.assertTrue('Vary' in rv.headers.keys())
-        self.assertEqual('Origin', rv.headers['Vary'])
+        self.assertEqual(rv.mimetype, "application/json")
+        self.assertTrue("Access-Control-Allow-Origin" in rv.headers.keys())
+        self.assertEqual("*", rv.headers["Access-Control-Allow-Origin"])
+        self.assertTrue("Vary" in rv.headers.keys())
+        self.assertEqual("Origin", rv.headers["Vary"])
         self.assertTrue(
-            'Access-Control-Allow-Credentials' in rv.headers.keys())
-        self.assertEqual('true',
-                         rv.headers['Access-Control-Allow-Credentials'])
+            "Access-Control-Allow-Credentials" in rv.headers.keys()
+        )
+        self.assertEqual(
+            "true", rv.headers["Access-Control-Allow-Credentials"]
+        )
+
+    @patch("ochazuke.api.views.get_remote_data")
+    def test_tsci_id(self, mock_get):
+        """/data/tsci-doc sends back JSON."""
+        mock_get.return_value = json.dumps(TSCI_ID)
+        rv = self.client.get("/data/tsci-doc")
+        self.assertIn('"currentDoc": "8sXj8GqhrdJhQdLk44"', rv.data.decode())
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.mimetype, "application/json")
+        self.assertTrue("Access-Control-Allow-Origin" in rv.headers.keys())
+        self.assertEqual("*", rv.headers["Access-Control-Allow-Origin"])
+        self.assertTrue("Vary" in rv.headers.keys())
+        self.assertEqual("Origin", rv.headers["Vary"])
+        self.assertTrue(
+            "Access-Control-Allow-Credentials" in rv.headers.keys()
+        )
+        self.assertEqual(
+            "true", rv.headers["Access-Control-Allow-Credentials"]
+        )
 
     def test_needsdiagnosis_without_params(self):
         """/data/needsdiagnosis-timeline without params fail."""
-        rv = self.client.get('/data/needsdiagnosis-timeline')
+        rv = self.client.get("/data/needsdiagnosis-timeline")
         self.assertEqual(rv.status_code, 404)
 
     def test_needsdiagnosis_invalid_param(self):
         """Ignore invalid parameters on /needsdiagnosis-timeline."""
-        rv = self.client.get('/data/needsdiagnosis-timeline?blah=foo')
+        rv = self.client.get("/data/needsdiagnosis-timeline?blah=foo")
         self.assertEqual(rv.status_code, 404)
 
     def test_needsdiagnosis_invalid_param_values(self):
         """Ignore invalid parameters values on /needsdiagnosis-timeline."""
-        rv = self.client.get('/data/needsdiagnosis-timeline?from=foo&to=bar')
+        rv = self.client.get("/data/needsdiagnosis-timeline?from=foo&to=bar")
         self.assertEqual(rv.status_code, 404)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For now this route just propagates the ID of the current spreadsheet, grabbing it from the endpoint set up by @miketaylr ([explained here](https://github.com/mozilla/webcompat-team-okrs/issues/105#issuecomment-557756943)) and serving it to the metrics client so that we can construct the full URL that will be displayed through the `iframe`.

r? @karlcow 