### PR TITLE
Issue #134 - Add endpoint for requesting firefox-interventions data.

### DIFF
--- a/tests/fixtures/firefox-interventions.json
+++ b/tests/fixtures/firefox-interventions.json
@@ -1,0 +1,58 @@
+[
+    {
+        "counters": {
+            "all": 4,
+            "android": 30,
+            "desktop": 16
+        },
+        "datetime": "2020-01-01T00:00:39.937Z"
+    },
+    {
+        "counters": {
+            "all": 4,
+            "android": 30,
+            "desktop": 16
+        },
+        "datetime": "2020-01-02T00:00:48.263Z"
+    },
+    {
+        "counters": {
+            "all": 4,
+            "android": 30,
+            "desktop": 16
+        },
+        "datetime": "2020-01-03T00:00:45.413Z"
+    },
+    {
+        "counters": {
+            "all": 4,
+            "android": 31,
+            "desktop": 16
+        },
+        "datetime": "2020-01-04T00:00:42.767Z"
+    },
+    {
+        "counters": {
+            "all": 4,
+            "android": 31,
+            "desktop": 16
+        },
+        "datetime": "2020-01-05T00:00:43.935Z"
+    },
+    {
+        "counters": {
+            "all": 4,
+            "android": 31,
+            "desktop": 16
+        },
+        "datetime": "2020-01-06T00:00:33.481Z"
+    },
+    {
+        "counters": {
+            "all": 4,
+            "android": 31,
+            "desktop": 16
+        },
+        "datetime": "2020-01-07T00:00:48.672Z"
+    }
+]

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -160,6 +160,24 @@ class APITestCase(unittest.TestCase):
         rv = self.client.get("/data/needsdiagnosis-timeline?from=foo&to=bar")
         self.assertEqual(rv.status_code, 404)
 
+    @patch("ochazuke.api.views.get_remote_data")
+    def firefox_interventions(self, mock_get):
+        """/data/triage-bugs sends back JSON."""
+        mock_get.return_value = json_data("firefox-interventions.json")
+        rv = self.client.get("/data/firefox-interventions?distribution=upstream&type=all&end=2020-01-01") # noqa
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.mimetype, "application/json")
+        self.assertTrue("Access-Control-Allow-Origin" in rv.headers.keys())
+        self.assertEqual("*", rv.headers["Access-Control-Allow-Origin"])
+        self.assertTrue("Vary" in rv.headers.keys())
+        self.assertEqual("Origin", rv.headers["Vary"])
+        self.assertTrue(
+            "Access-Control-Allow-Credentials" in rv.headers.keys()
+        )
+        self.assertEqual(
+            "true", rv.headers["Access-Control-Allow-Credentials"]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_tools_helpers.py
+++ b/tests/unit/test_tools_helpers.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Main testing module for Webcompat Metrics Server."""
+import unittest
+
+from tools import helpers
+
+
+class ToolsHelpersTestCase(unittest.TestCase):
+    """General Test Cases for global helpers."""
+
+    def test_url_with_params(self):
+        """Given a dict of parameters and a URL, returns an encoded URL."""
+        url = "https://example.com/test"
+        parameters = {
+            "test": "example",
+            "hello=world": "this/needs/encoding"
+        }
+        expected = "https://example.com/test?test=example&hello%3Dworld=this%2Fneeds%2Fencoding" # noqa
+
+        self.assertEqual(helpers.url_with_params(url, parameters), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Some helpers for the tools section."""
 
+from urllib.parse import urlencode
 from urllib.request import Request
 from urllib.request import urlopen
 
@@ -16,3 +17,8 @@ def get_remote_data(url):
     req.add_header('Accept', 'application/json')
     json_response = urlopen(req, timeout=240).read()
     return json_response
+
+
+def url_with_params(url, params):
+    """Builds a full URL with encoded parameters."""
+    return url + "?" + urlencode(params)


### PR DESCRIPTION
This PR adds an endpoint to allow us building a graph showing historical Firefox intervention counters. :) Valid requests look like `/data/firefox-interventions?distribution=upstream&type=all&start=2020-01-01`, where the parameters are:

* `distribution`: One of `android-components`, `mozilla-beta`, `mozilla-central`, `mozilla-release`, `upstream`
* `type`: One of `all`, `injection`, `ua_override`
* `start`: Optional, `YYYY-MM-DD` from where to start providing history
* `end`: Optional, `YYYY-MM-DD` from where to end providing history

I didn't add validation for the query parameters in this project, because I filter them on the awhtwy-server. The available distributions and types are subject to change, and not duplicating that info makes it a bit easier. However, I understand if it's preferred to have a filter in this project as well, let me know.

It looks like we don't have documentation on all API endpoints. If we have, and I did miss them, sorry! Please point me to it and I'll add documentation.

r? @karlcow 

Closes #134